### PR TITLE
CMakeLists: fix for idf 5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ endif()
 idf_component_register(
     SRC_DIRS ${MODULES}
     INCLUDE_DIRS .
+<<<<<<< Updated upstream
     REQUIRES driver
+=======
+    PRIV_REQUIRES driver
+>>>>>>> Stashed changes
     )
-


### PR DESCRIPTION
idf 5 requires adding PRIV_REQUIRES directive for importing components from another component.